### PR TITLE
also copy PeerAddr and PeerHost (common usage) to start_SSL

### DIFF
--- a/lib/Net/HTTPS/NB.pm
+++ b/lib/Net/HTTPS/NB.pm
@@ -169,7 +169,7 @@ sub new {
 		or return;
 	
 	# and upgrade it to SSL then                                        for SNI
-	$class->start_SSL($self, %ssl_opts, SSL_startHandshake => 0, PeerHost => $args{Host})
+	$class->start_SSL($self, %ssl_opts, SSL_startHandshake => 0, PeerHost => $args{Host} || $args{PeerHost} || $args{PeerAddr})
 		or return;
 	
 	if (!exists($args{Blocking}) || $args{Blocking}) {


### PR DESCRIPTION
Since Net::HTTP* inherits from IO::Socket::* classes, PeerAddr and PeerHost are common used keys. Therefore it would be nice, if Net::HTTPS::NB would copy its value to start_SSL, if this is possible and makes sense.
Thx, Andreas